### PR TITLE
Support combination billing plans

### DIFF
--- a/.changeset/serious-tables-taste.md
+++ b/.changeset/serious-tables-taste.md
@@ -1,0 +1,5 @@
+---
+'@shopify/shopify-api': minor
+---
+
+Support combination billing plans

--- a/docs/guides/billing.md
+++ b/docs/guides/billing.md
@@ -71,6 +71,18 @@ This setting is a collection of billing plans. Each billing plan allows the foll
 
 1. Prior to `ApiVersion.April23` the currency code must be `USD`.
 
+### Combination Billing Plans
+
+| Parameter             | Type                         | Required? | Default Value | Notes                                                                                                                                                            |
+| --------------------- | ---------------------------- | :-------: | :-----------: | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `interval`            | `COMBINATION`                      |    Yes    |       -       | `BillingInterval.Combination`                                                                                                                                          |
+| `subscriptionPlan` | `BillingConfigSubscriptionPlan` |    Yes     |       -       | `BillingConfigSubscriptionPlan` value other than `interval`, `trialDays` and `replacementBehavior`, see [Recurring Billing Plan](#recurring-billing-plans) for more information. |
+| `usagePlan` | `BillingConfigUsagePlan` |    Yes     |       -       | `BillingConfigUsagePlan` value other than `interval`, `trialDays` and `replacementBehavior`, see [Usage Billing Plan](#usage-billing-plans) for more information. |
+| `trialDays`           | `number`                     |    No     |       -       | Give merchants this many days before charging                                                                                                                    |
+| `replacementBehavior` | `BillingReplacementBehavior` |    No     |       -       | `BillingReplacementBehavior` value, see [the reference](https://shopify.dev/docs/api/admin-graphql/latest/mutations/appSubscriptionCreate) for more information. |
+
+> **Note** `interval` of the subscription plan is fixed at `EVERY_30_DAYS`.
+
 ## When should the app check for payment?
 
 As mentioned above, billing requires a session to access the API, which means that the app must actually be installed before it can request payment.

--- a/lib/billing/types.ts
+++ b/lib/billing/types.ts
@@ -45,11 +45,26 @@ export interface BillingConfigUsagePlan extends BillingConfigPlan {
   replacementBehavior?: BillingReplacementBehavior;
 }
 
+export interface BillingConfigCombinationPlan {
+  interval: BillingInterval.Combination;
+  subscriptionPlan: Omit<
+    BillingConfigSubscriptionPlan,
+    'interval' | 'trialDays' | 'replacementBehavior'
+  >;
+  usagePlan: Omit<
+    BillingConfigUsagePlan,
+    'interval' | 'trialDays' | 'replacementBehavior'
+  >;
+  trialDays?: number;
+  replacementBehavior?: BillingReplacementBehavior;
+}
+
 export interface BillingConfig {
   [plan: string]:
     | BillingConfigOneTimePlan
     | BillingConfigSubscriptionPlan
-    | BillingConfigUsagePlan;
+    | BillingConfigUsagePlan
+    | BillingConfigCombinationPlan;
 }
 
 export interface BillingCheckParams {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -47,6 +47,7 @@ export enum BillingInterval {
   Every30Days = 'EVERY_30_DAYS',
   Annual = 'ANNUAL',
   Usage = 'USAGE',
+  Combination = 'COMBINATION',
 }
 
 export type RecurringBillingIntervals = Exclude<


### PR DESCRIPTION
<!--
  ☝️How to write a good PR title:
  - Prefix it with [Feature] (if applicable)
  - Start with a verb, for example: Add, Delete, Improve, Fix…
  - Give as much context as necessary and as little as possible
  - Prefix it with [WIP] while it’s a work in progress
-->

### WHY are these changes introduced?

Fixes #919 <!-- link to issue if one exists -->

<!--
  Context about the problem that’s being addressed.
-->
Because a combination of a recurring billing plan and a usage billing plan was not supported.

### WHAT is this pull request doing?

<!--
  Summary of the changes committed.
  Before / after screenshots appreciated for UI changes, if applicable.
-->

* Add billing interval type for combination (BillingInterval.Combination)
* Support a combination of a recurring billing plan and a usage billing plan

## Type of change

- [ ] Patch: Bug (non-breaking change which fixes an issue)
- [x] Minor: New feature (non-breaking change which adds functionality)
- [ ] Major: Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have used `yarn changeset` to create a draft changelog entry (do NOT update the `CHANGELOG.md` file manually)
- [x] I have added/updated tests for this change
- [x] I have documented new APIs/updated the documentation for modified APIs (for public APIs)
